### PR TITLE
Update actionbar id

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -87,7 +87,7 @@ javadoc {
             'https://google.github.io/guava/releases/25.1-jre/api/docs/',
             'https://google.github.io/guice/api-docs/5.0.1/javadoc/',
             'https://docs.oracle.com/en/java/javase/11/docs/api//',
-            'https://jd.adventure.kyori.net/api/4.7.0/'
+            "https://jd.adventure.kyori.net/api/${adventureVersion}/"
     )
 
     // Disable the crazy super-strict doclint tool in Java 8

--- a/api/src/main/java/com/velocitypowered/api/event/EventTask.java
+++ b/api/src/main/java/com/velocitypowered/api/event/EventTask.java
@@ -75,7 +75,7 @@ public interface EventTask {
   }
 
   /**
-   * Creates an continuation based {@link EventTask} from the given {@link Consumer}. The task isn't
+   * Creates a continuation based {@link EventTask} from the given {@link Consumer}. The task isn't
    * guaranteed to be executed asynchronously ({@link #requiresAsync()} always returns
    * {@code false}).
    *
@@ -99,8 +99,9 @@ public interface EventTask {
   }
 
   /**
-   * Creates an continuation based {@link EventTask} for the given {@link CompletableFuture}. The
-   * continuation will be notified once the given future is completed.
+   * Creates a continuation based {@link EventTask} for the given {@link CompletableFuture}. The
+   * continuation is resumed upon completion of the given {@code future}, whether it is completed
+   * successfully or not.
    *
    * @param future The task to wait for
    * @return The event task

--- a/api/src/main/java/com/velocitypowered/api/event/player/KickedFromServerEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/KickedFromServerEvent.java
@@ -130,8 +130,7 @@ public final class KickedFromServerEvent implements
   }
 
   /**
-   * Tells the proxy to redirect the player to another server. No messages will be sent from the
-   * proxy when this result is used.
+   * Tells the proxy to redirect the player to another server.
    */
   public static final class RedirectPlayer implements ServerKickResult {
 
@@ -159,8 +158,11 @@ public final class KickedFromServerEvent implements
 
     /**
      * Creates a new redirect result to forward the player to the specified {@code server}.
+     * The specified {@code message} will be sent to the player after the redirection.
+     * Use {@code Component.empty()} to skip sending any messages to the player.
      *
      * @param server the server to send the player to
+     * @param message the message will be sent to the player after redirecting
      * @return the redirect result
      */
     public static RedirectPlayer create(RegisteredServer server,
@@ -168,6 +170,13 @@ public final class KickedFromServerEvent implements
       return new RedirectPlayer(server, message);
     }
 
+    /**
+     * Creates a new redirect result to forward the player to the specified {@code server}.
+     * The kick reason will be displayed to the player
+     *
+     * @param server the server to send the player to
+     * @return the redirect result
+     */
     public static ServerKickResult create(RegisteredServer server) {
       return new RedirectPlayer(server, null);
     }

--- a/api/src/main/java/com/velocitypowered/api/event/player/PlayerClientBrandEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/PlayerClientBrandEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.event.player;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.proxy.Player;
+
+/**
+ * Fired when a {@link Player} sends the <code>minecraft:brand</code> plugin message.
+ */
+public final class PlayerClientBrandEvent {
+  private final Player player;
+  private final String brand;
+
+  /**
+   * Creates a new instance.
+   *
+   * @param player the {@link Player} of the sent client brand
+   * @param brand the sent client brand
+   */
+  public PlayerClientBrandEvent(Player player, String brand) {
+    this.player = Preconditions.checkNotNull(player);
+    this.brand = Preconditions.checkNotNull(brand);
+  }
+
+  public Player getPlayer() {
+    return player;
+  }
+
+  public String getBrand() {
+    return brand;
+  }
+
+  @Override
+  public String toString() {
+    return "PlayerClientBrandEvent{"
+      + "player=" + player
+      + ", brand='" + brand + '\''
+      + '}';
+  }
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
 
     ext {
         // dependency versions
-        adventureVersion = '4.9.1'
+        adventureVersion = '4.9.2'
         junitVersion = '5.7.0'
         slf4jVersion = '1.7.30'
         log4jVersion = '2.14.1'

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -143,9 +143,14 @@ public class VelocityCommandManager implements CommandManager {
   @Override
   public void unregister(final String alias) {
     Preconditions.checkNotNull(alias, "alias");
-    // The literals of secondary aliases will preserve the children of
-    // the removed literal in the graph.
-    dispatcher.getRoot().removeChildByName(alias.toLowerCase(Locale.ENGLISH));
+    lock.writeLock().lock();
+    try {
+      // The literals of secondary aliases will preserve the children of
+      // the removed literal in the graph.
+      dispatcher.getRoot().removeChildByName(alias.toLowerCase(Locale.ENGLISH));
+    } finally {
+      lock.writeLock().unlock();
+    }
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -424,9 +424,10 @@ public class VelocityConfiguration implements ProxyConfig {
     CommentedFileConfig defaultConfig = CommentedFileConfig.of(tmpFile, TomlFormat.instance());
     defaultConfig.load();
 
-    // Handle any cases where the config needs to be saved again
+    // Retrieve the forwarding secret. First, from environment variable, then from config.
     byte[] forwardingSecret;
-    String forwardingSecretString = config.get("forwarding-secret");
+    String forwardingSecretString = System.getenv()
+        .getOrDefault("VELOCITY_FORWARDING_SECRET", config.get("forwarding-secret"));
     if (forwardingSecretString == null || forwardingSecretString.isEmpty()) {
       forwardingSecretString = generateRandomString(12);
       config.set("forwarding-secret", forwardingSecretString);
@@ -434,6 +435,7 @@ public class VelocityConfiguration implements ProxyConfig {
     }
     forwardingSecret = forwardingSecretString.getBytes(StandardCharsets.UTF_8);
 
+    // Handle any cases where the config needs to be saved again
     if (mustResave) {
       config.save();
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -173,7 +173,9 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
     } else if (proxyPlayer.getConnection().getType() == ConnectionTypes.LEGACY_FORGE) {
       handshake.setServerAddress(destAddress.getHostString() + HANDSHAKE_HOSTNAME_TOKEN);
     } else {
-      handshake.setServerAddress(destAddress.getHostString());
+      handshake.setServerAddress(proxyPlayer.getVirtualHost()
+          .orElseGet(() -> registeredServer.getServerInfo().getAddress())
+          .getHostString());
     }
     handshake.setPort(destAddress.getPort());
     mc.delayedWrite(handshake);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -56,6 +56,7 @@ import com.velocitypowered.proxy.protocol.packet.TabCompleteResponse;
 import com.velocitypowered.proxy.protocol.packet.TabCompleteResponse.Offer;
 import com.velocitypowered.proxy.protocol.packet.title.GenericTitlePacket;
 import com.velocitypowered.proxy.protocol.util.PluginMessageUtil;
+import com.velocitypowered.proxy.util.CharacterUtil;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
@@ -153,6 +154,12 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
     }
 
     String msg = packet.getMessage();
+    if (CharacterUtil.containsIllegalCharacters(msg)) {
+      player.disconnect(Component.translatable("velocity.error.illegal-chat-characters",
+          NamedTextColor.RED));
+      return true;
+    }
+
     if (msg.startsWith("/")) {
       String originalCommand = msg.substring(1);
       server.getCommandManager().callCommandEvent(player, msg.substring(1))
@@ -629,4 +636,5 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
       }
     }
   }
+
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -27,6 +27,7 @@ import com.velocitypowered.api.event.command.CommandExecuteEvent.CommandResult;
 import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.event.player.PlayerChannelRegisterEvent;
 import com.velocitypowered.api.event.player.PlayerChatEvent;
+import com.velocitypowered.api.event.player.PlayerClientBrandEvent;
 import com.velocitypowered.api.event.player.PlayerResourcePackStatusEvent;
 import com.velocitypowered.api.event.player.TabCompleteEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
@@ -236,7 +237,9 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
         player.getKnownChannels().removeAll(PluginMessageUtil.getChannels(packet));
         backendConn.write(packet.retain());
       } else if (PluginMessageUtil.isMcBrand(packet)) {
-        player.setClientBrand(PluginMessageUtil.readBrandMessage(packet.content()));
+        String brand = PluginMessageUtil.readBrandMessage(packet.content());
+        server.getEventManager().fireAndForget(new PlayerClientBrandEvent(player, brand));
+        player.setClientBrand(brand);
         backendConn.write(PluginMessageUtil
             .rewriteMinecraftBrand(packet, server.getVersion(), player.getProtocolVersion()));
       } else if (BungeeCordMessageResponder.isBungeeCordMessage(packet)) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -414,7 +414,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
       connection.write(titlePkt);
     } else if (part == TitlePart.SUBTITLE) {
       GenericTitlePacket titlePkt = GenericTitlePacket.constructTitlePacket(
-          GenericTitlePacket.ActionType.SET_TITLE, this.getProtocolVersion());
+          GenericTitlePacket.ActionType.SET_SUBTITLE, this.getProtocolVersion());
       titlePkt.setComponent(serializer.serialize(translateMessage((Component) value)));
       connection.write(titlePkt);
     } else if (part == TitlePart.TIMES) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -641,7 +641,9 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
                       if (requestedMessage == null) {
                         requestedMessage = friendlyReason;
                       }
-                      sendMessage(requestedMessage);
+                      if (requestedMessage != Component.empty()) {
+                        sendMessage(requestedMessage);
+                      }
                       break;
                     default:
                       // The only remaining value is successful (no need to do anything!)

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -404,6 +404,10 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
       throw new NullPointerException("value");
     }
 
+    if (this.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_8) < 0) {
+      return;
+    }
+
     GsonComponentSerializer serializer = ProtocolUtils.getJsonChatSerializer(this
         .getProtocolVersion());
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/CharacterUtil.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/CharacterUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.util;
+
+public final class CharacterUtil {
+
+  /**
+   * Checks if a character is allowed.
+   * @param c character to check
+   * @return true if the character is allowed
+   */
+  public static boolean isAllowedCharacter(char c) {
+    // 167 = §, 127 = DEL
+    // https://minecraft.fandom.com/wiki/Multiplayer#Chat
+    return c != 167 && c >= ' ' && c != 127;
+  }
+
+  /**
+   * It is not possible to send certain characters in the chat like:
+   * section symbol, DEL, and all characters below space.
+   * Checks if a message contains illegal characters.
+   * @param message the message to check
+   * @return true if the message contains illegal characters
+   */
+  public static boolean containsIllegalCharacters(String message) {
+    for (int i = 0; i < message.length(); i++) {
+      if (!isAllowedCharacter(message.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
@@ -29,6 +29,7 @@ velocity.error.modern-forwarding-needs-new-client=This server is only compatible
 velocity.error.modern-forwarding-failed=Your server did not send a forwarding request to the proxy. Make sure the server is configured for Velocity forwarding.
 velocity.error.moved-to-new-server=You were kicked from {0}: {1}
 velocity.error.no-available-servers=There are no available servers to connect you to. Try again later or contact an admin.
+velocity.error.illegal-chat-characters=Illegal characters in chat
 
 # Commands
 velocity.command.generic-error=An error occurred while running this command.

--- a/proxy/src/test/java/com/velocitypowered/proxy/event/EventTaskTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/event/EventTaskTest.java
@@ -1,0 +1,118 @@
+package com.velocitypowered.proxy.event;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.velocitypowered.api.event.Continuation;
+import com.velocitypowered.api.event.EventTask;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+public class EventTaskTest {
+
+  @Test
+  public void testResumeWhenCompleteNormal() {
+    WitnessContinuation continuation = new WitnessContinuation();
+    CompletableFuture<Void> completed = CompletableFuture.completedFuture(null);
+    EventTask.resumeWhenComplete(completed).execute(continuation);
+    assertTrue(continuation.completedSuccessfully(), "Completed future did not "
+        + "complete successfully");
+  }
+
+  @Test
+  public void testResumeWhenCompleteException() {
+    WitnessContinuation continuation = new WitnessContinuation();
+    CompletableFuture<Void> failed = CompletableFuture.failedFuture(new Throwable());
+    EventTask.resumeWhenComplete(failed).execute(continuation);
+    assertTrue(continuation.completedWithError(), "Failed future completed successfully");
+  }
+
+  @Test
+  public void testResumeWhenCompleteFromOtherThread() throws InterruptedException {
+    WitnessContinuation continuation = new WitnessContinuation();
+    CountDownLatch latch = new CountDownLatch(1);
+    continuation.onComplete = (ignored) -> latch.countDown();
+    CompletableFuture<Void> async = CompletableFuture.supplyAsync(() -> null);
+    EventTask.resumeWhenComplete(async).execute(continuation);
+    latch.await();
+
+    assertTrue(continuation.completedSuccessfully(), "Completed future did not "
+        + "complete successfully");
+  }
+
+  @Test
+  public void testResumeWhenFailFromOtherThread() throws InterruptedException {
+    WitnessContinuation continuation = new WitnessContinuation();
+    CountDownLatch latch = new CountDownLatch(1);
+    continuation.onComplete = (ignored) -> latch.countDown();
+    CompletableFuture<Void> async = CompletableFuture.supplyAsync(() -> {
+      throw new RuntimeException();
+    });
+    EventTask.resumeWhenComplete(async).execute(continuation);
+    latch.await();
+
+    assertTrue(continuation.completedWithError(), "Failed future completed successfully");
+  }
+
+  @Test
+  public void testResumeWhenFailFromOtherThreadComplexChain() throws InterruptedException {
+    WitnessContinuation continuation = new WitnessContinuation();
+    CountDownLatch latch = new CountDownLatch(1);
+    continuation.onComplete = (ignored) -> latch.countDown();
+    CompletableFuture<Void> async = CompletableFuture.supplyAsync(() -> null)
+            .thenAccept((v) -> {
+              throw new RuntimeException();
+            })
+            .thenCompose((v) -> CompletableFuture.completedFuture(null));
+    EventTask.resumeWhenComplete(async).execute(continuation);
+    latch.await();
+
+    assertTrue(continuation.completedWithError(), "Failed future completed successfully");
+  }
+
+  /**
+   * An extremely simplified implementation of {@link Continuation} for verifying the completion
+   * of an operation.
+   */
+  private static class WitnessContinuation implements Continuation {
+
+    private static final AtomicIntegerFieldUpdater<WitnessContinuation> STATUS_UPDATER =
+        AtomicIntegerFieldUpdater.newUpdater(WitnessContinuation.class, "status");
+
+    private static final int UNCOMPLETED = 0;
+    private static final int COMPLETED = 1;
+    private static final int COMPLETED_WITH_EXCEPTION = 2;
+
+    private volatile int status = UNCOMPLETED;
+    private Consumer<Throwable> onComplete;
+
+    @Override
+    public void resume() {
+      if (!STATUS_UPDATER.compareAndSet(this, UNCOMPLETED, COMPLETED)) {
+        throw new IllegalStateException("Continuation is already completed");
+      }
+
+      this.onComplete.accept(null);
+    }
+
+    @Override
+    public void resumeWithException(Throwable exception) {
+      if (!STATUS_UPDATER.compareAndSet(this, UNCOMPLETED, COMPLETED_WITH_EXCEPTION)) {
+        throw new IllegalStateException("Continuation is already completed");
+      }
+
+      this.onComplete.accept(exception);
+    }
+
+    public boolean completedSuccessfully() {
+      return STATUS_UPDATER.get(this) == COMPLETED;
+    }
+
+    public boolean completedWithError() {
+      return STATUS_UPDATER.get(this) == COMPLETED_WITH_EXCEPTION;
+    }
+  }
+
+}

--- a/proxy/src/test/java/com/velocitypowered/proxy/event/EventTaskTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/event/EventTaskTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.velocitypowered.proxy.event;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/proxy/src/test/java/com/velocitypowered/proxy/util/CharacterUtilTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/util/CharacterUtilTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CharacterUtilTest {
+
+  private static final String CHARACTERS = "!\\\"#$%&'()*+,-./0123456789:;<=>?"
+      + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_'abcdefghijklmnopqrstuvwxyz¡«»";
+  private static final String NON_ASCII_CHARACTERS = "速度ъगꯀ▀";
+
+  @Test
+  void testCharacter() {
+    assertTrue(CharacterUtil.isAllowedCharacter('a'));
+    assertTrue(CharacterUtil.isAllowedCharacter(' '));
+
+    assertFalse(CharacterUtil.isAllowedCharacter('\u00A7')); // §
+    assertFalse(CharacterUtil.isAllowedCharacter('\u007F')); // DEL
+    assertFalse(CharacterUtil.isAllowedCharacter((char) 0));
+  }
+
+  @Test
+  public void testMessage() {
+    assertFalse(CharacterUtil.containsIllegalCharacters(""));
+    assertFalse(CharacterUtil.containsIllegalCharacters(" "));
+    assertFalse(CharacterUtil.containsIllegalCharacters("Velocity"));
+    assertFalse(CharacterUtil.containsIllegalCharacters(CHARACTERS));
+    assertFalse(CharacterUtil.containsIllegalCharacters(NON_ASCII_CHARACTERS));
+
+    assertTrue(CharacterUtil.containsIllegalCharacters("§cVelocity"));
+    assertTrue(CharacterUtil.containsIllegalCharacters("§"));
+  }
+}


### PR DESCRIPTION
looks like my branch also updates your branch with the latest commits from velocity :eyes:

anyways, my testing concludes that the actionbar packet id is 0x42.
my test code is this (used fabric for this, hence the mixins): 
```java
@Mixin(value = NetworkState.PacketHandler.class)
public class NetworkStateMixin {

  private AtomicInteger packetId = new AtomicInteger(0);

  @Inject(method = "register", at = @At("HEAD"))
  public <P> void injectRegister(
      Class<P> type,
      Function<PacketByteBuf, P> packetFactory,
      CallbackInfoReturnable<NetworkState.PacketHandler> cir) {
    packetId.incrementAndGet();
    if (type.isAssignableFrom(OverlayMessageS2CPacket.class)) {
      ExampleMod.LOGGER.info("ActionBar id :" + packetId.get());
    }
  }
}
```
And got an output of `[19:46:50] [Netty Client IO #0/INFO]: ActionBar id :66` , translating to `0x42`

I may have a mistake in my code, and if I do, apologies for the inconvenience. 